### PR TITLE
feat: Enhance NAT events and extend byte counters

### DIFF
--- a/ipt_NETFLOW.h
+++ b/ipt_NETFLOW.h
@@ -77,7 +77,7 @@ struct netflow5_pdu {
 		one(id, a, len)	\
 		one(id, b, len)
 #define Elements \
-	two(1,   IN_BYTES, octetDeltaCount, 4) \
+	two(1,   IN_BYTES, octetDeltaCount, 8) \
 	two(2,   IN_PKTS, packetDeltaCount, 4) \
 	two(4,   PROTOCOL, protocolIdentifier, 1) \
 	two(5,   TOS, ipClassOfService, 1) \
@@ -93,6 +93,8 @@ struct netflow5_pdu {
 	two(15,  IPV4_NEXT_HOP, ipNextHopIPv4Address, 4) \
 	two(21,  LAST_SWITCHED, flowEndSysUpTime, 4) \
 	two(22,  FIRST_SWITCHED, flowStartSysUpTime, 4) \
+	two(23,  OUT_BYTES, octetDeltaCountOut, 8) \
+	two(24,  OUT_PKTS, packetDeltaCountOut, 4) \
 	one(25,  minimumIpTotalLength, 2) \
 	one(26,  maximumIpTotalLength, 2) \
 	two(27,  IPV6_SRC_ADDR, sourceIPv6Address, 16) \


### PR DESCRIPTION
This commit introduces two main improvements to NAT event reporting and data precision.

The `octetDeltaCount` (IN_BYTES) and the new `octetDeltaCountOut` (OUT_BYTES) fields are extended from 4 to 8 bytes. This prevents counter rollovers for large flows on high-speed links.

NAT event reporting is enhanced to include inbound and outbound packet and byte counts (`IN_PKTS`, `IN_BYTES`, `OUT_PKTS`, `OUT_BYTES`) directly within the NAT event template. This simplifies the export logic by removing the need to generate a separate, secondary flow for the reply direction of a NAT'd connection.

The changes align the NAT event structure with modern flow reporting standards and improve data accuracy.