### PR TITLE
flows_dump_seq_show: fix table when no VLAN

### DIFF
--- a/ipt_NETFLOW.c
+++ b/ipt_NETFLOW.c
@@ -1153,6 +1153,8 @@ static int flows_dump_seq_show(struct seq_file *seq, void *v)
 		seq_printf(seq, " %d", ntohs(nf->tuple.tag[0]));
 		if (nf->tuple.tag[1])
 			seq_printf(seq, ",%d", ntohs(nf->tuple.tag[1]));
+	} else {
+		seq_printf(seq, " -");
 	}
 #endif
 #if defined(ENABLE_MAC) || defined(ENABLE_VLAN)


### PR DESCRIPTION
When no VLAN nothing was output, so columns were off.
Output "-" when no VLAN so that tools can parse table properly.